### PR TITLE
use a temporary directory for all test output

### DIFF
--- a/tests/test_dcmip_setup.py
+++ b/tests/test_dcmip_setup.py
@@ -5,7 +5,7 @@ from firedrake import IcosahedralSphereMesh, ExtrudedMesh, Expression, \
 import numpy as np
 
 
-def setup_dcmip():
+def setup_dcmip(dirname):
 
     nlayers = 2         # 2 horizontal layers
     refinements = 3      # number of horizontal cells = 20*(4^refinements)
@@ -41,7 +41,7 @@ def setup_dcmip():
 
     fieldlist = ['u', 'rho', 'theta']
     timestepping = TimesteppingParameters(dt=10.0)
-    output = OutputParameters(Verbose=True, dumpfreq=1, dirname='tests/dcmip')
+    output = OutputParameters(Verbose=True, dumpfreq=1, dirname=dirname+"/dcmip")
     parameters = CompressibleParameters(k=k, Omega=Omega)
 
     state = Compressible3DState(mesh, vertical_degree=1, horizontal_degree=1,
@@ -146,12 +146,13 @@ def setup_dcmip():
     return stepper, timestepping.dt
 
 
-def run_dcmip():
+def run_dcmip(dirname):
 
-    stepper, dt = setup_dcmip()
+    stepper, dt = setup_dcmip(dirname)
     stepper.run(t=0, tmax=dt)
 
 
-def test_dcmip_runs():
+def test_dcmip_runs(tmpdir):
 
-    run_dcmip()
+    dirname = str(tmpdir)
+    run_dcmip(dirname)

--- a/tests/test_sw_triangle.py
+++ b/tests/test_sw_triangle.py
@@ -3,7 +3,7 @@ from firedrake import IcosahedralSphereMesh, Expression, SpatialCoordinate, \
     Constant, as_vector
 
 
-def setup_sw():
+def setup_sw(dirname):
 
     refinements = 3  # number of horizontal cells = 20*(4^refinements)
 
@@ -19,7 +19,7 @@ def setup_sw():
 
     fieldlist = ['u', 'D']
     timestepping = TimesteppingParameters()
-    output = OutputParameters(dumplist=(True,True), dirname='tests/sw')
+    output = OutputParameters(dumplist=(True,True), dirname=dirname)
     parameters = ShallowWaterParameters()
 
     state = ShallowWaterState(mesh, vertical_degree=None, horizontal_degree=2,
@@ -46,11 +46,12 @@ def setup_sw():
     state.initialise([u0, D0])
 
 
-def run_sw():
+def run_sw(dirname):
 
-    setup_sw()
+    setup_sw(dirname)
 
 
-def test_sw_setup():
+def test_sw_setup(tmpdir):
 
-    run_sw()
+    dirname = str(tmpdir)
+    run_sw(dirname)

--- a/tests/test_sw_triangle.py
+++ b/tests/test_sw_triangle.py
@@ -19,7 +19,7 @@ def setup_sw(dirname):
 
     fieldlist = ['u', 'D']
     timestepping = TimesteppingParameters()
-    output = OutputParameters(dumplist=(True,True), dirname=dirname)
+    output = OutputParameters(dumplist=(True,True), dirname=dirname+"/sw")
     parameters = ShallowWaterParameters()
 
     state = ShallowWaterState(mesh, vertical_degree=None, horizontal_degree=2,


### PR DESCRIPTION
@wence- it seems like pytest creates the tmpdir which causes a slight problem as the dcore code expects to be creating a new directory for output so that results don't get overwritten. i've got round it by making a subdirectory of the tmpdir. Is there a better way?